### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete URL scheme check

### DIFF
--- a/src/utils/permalinks.ts
+++ b/src/utils/permalinks.ts
@@ -47,7 +47,9 @@ export const getPermalink = (slug = '', type = 'page'): string => {
     slug.startsWith('http://') ||
     slug.startsWith('://') ||
     slug.startsWith('#') ||
-    slug.startsWith('javascript:')
+    slug.startsWith('javascript:') ||
+    slug.startsWith('data:') ||
+    slug.startsWith('vbscript:')
   ) {
     return slug;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/BC-Robotics-4504/bcr-site/security/code-scanning/1](https://github.com/BC-Robotics-4504/bcr-site/security/code-scanning/1)

To fix the issue, the function should check if the `slug` string starts with any of the potentially dangerous schemes, not just `javascript:`. Specifically, in addition to the existing check for `javascript:`, add checks for `data:` and `vbscript:`, using the same string prefix matching. Place all checks in a single `if` clause with a clear logical or (`||`) condition. No changes in existing functionality should be made—just extend the schemes checked.

Update only the relevant `if` block inside the `getPermalink` function in `src/utils/permalinks.ts` (lines 45-52). No new methods or imports are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
